### PR TITLE
feat: add @go.Package annotations to all Pkl modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,5 @@
 ## Coding Guidelines
 - Always use conventional commit description format
+
+## Language References
+- pkl language reference can be found at https://pkl-lang.org/main/current/language-reference/index.html

--- a/PklProject
+++ b/PklProject
@@ -11,4 +11,10 @@ package {
     packageZipUrl = "https://github.com/declix/\(name)/releases/download/\(version)/\(name)@\(version).zip"
 }
 
+dependencies {
+    ["go"] {
+        uri = "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0"
+    }
+}
+
 tests = import*("**/tests.pkl").keys.toListing()

--- a/PklProject.deps.json
+++ b/PklProject.deps.json
@@ -1,4 +1,12 @@
 {
   "schemaVersion": 1,
-  "resolvedDependencies": {}
+  "resolvedDependencies": {
+    "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0": {
+      "type": "remote",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0",
+      "checksums": {
+        "sha256": "cc351272251f7d0c93cd93de413f49898effcc432d832135ee9412dda39aea89"
+      }
+    }
+  }
 }

--- a/apt/apt.pkl
+++ b/apt/apt.pkl
@@ -1,7 +1,7 @@
 @go.Package { name = "github.com/declix/pkl-declix/apt" }
 abstract module declix.apt
 
-import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
+import "@go/go.pkl"
 import ".../declix.pkl"
 import ".../dpkg/dpkg.pkl"
 

--- a/apt/apt.pkl
+++ b/apt/apt.pkl
@@ -1,5 +1,7 @@
+@go.Package { name = "github.com/declix/pkl-declix/apt" }
 abstract module declix.apt
 
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
 import ".../declix.pkl"
 import ".../dpkg/dpkg.pkl"
 

--- a/declix.pkl
+++ b/declix.pkl
@@ -1,5 +1,7 @@
+@go.Package { name = "github.com/declix/pkl-declix" }
 module declix
 
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
 import "pkl:base"
 
 abstract class Resource { 

--- a/declix.pkl
+++ b/declix.pkl
@@ -1,7 +1,7 @@
 @go.Package { name = "github.com/declix/pkl-declix" }
 module declix
 
-import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
+import "@go/go.pkl"
 import "pkl:base"
 
 abstract class Resource { 

--- a/dpkg/dpkg.pkl
+++ b/dpkg/dpkg.pkl
@@ -1,7 +1,7 @@
 @go.Package { name = "github.com/declix/pkl-declix/dpkg" }
 module declix.dpkg
 
-import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
+import "@go/go.pkl"
 import ".../declix.pkl"
 
 class Package extends declix.Resource {

--- a/dpkg/dpkg.pkl
+++ b/dpkg/dpkg.pkl
@@ -1,5 +1,7 @@
+@go.Package { name = "github.com/declix/pkl-declix/dpkg" }
 module declix.dpkg
 
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
 import ".../declix.pkl"
 
 class Package extends declix.Resource {

--- a/fs/fs.pkl
+++ b/fs/fs.pkl
@@ -1,7 +1,7 @@
 @go.Package { name = "github.com/declix/pkl-declix/fs" }
 abstract module declix.fs
 
-import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
+import "@go/go.pkl"
 import ".../declix.pkl"
 
 typealias Missing = declix.Missing

--- a/fs/fs.pkl
+++ b/fs/fs.pkl
@@ -1,5 +1,7 @@
+@go.Package { name = "github.com/declix/pkl-declix/fs" }
 abstract module declix.fs
 
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
 import ".../declix.pkl"
 
 typealias Missing = declix.Missing

--- a/resources.pkl
+++ b/resources.pkl
@@ -1,7 +1,7 @@
 @go.Package { name = "github.com/declix/pkl-declix/resources" }
 module declix.resources
 
-import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
+import "@go/go.pkl"
 import "declix.pkl"
 
 resources: Listing<declix.Resource>

--- a/resources.pkl
+++ b/resources.pkl
@@ -1,5 +1,7 @@
+@go.Package { name = "github.com/declix/pkl-declix/resources" }
 module declix.resources
 
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
 import "declix.pkl"
 
 resources: Listing<declix.Resource>

--- a/systemd/systemd.pkl
+++ b/systemd/systemd.pkl
@@ -1,7 +1,7 @@
 @go.Package { name = "github.com/declix/pkl-declix/systemd" }
 abstract module declix.systemd
 
-import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
+import "@go/go.pkl"
 import ".../declix.pkl"
 
 class Unit extends declix.Resource {

--- a/systemd/systemd.pkl
+++ b/systemd/systemd.pkl
@@ -1,5 +1,7 @@
+@go.Package { name = "github.com/declix/pkl-declix/systemd" }
 abstract module declix.systemd
 
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
 import ".../declix.pkl"
 
 class Unit extends declix.Resource {

--- a/user/user.pkl
+++ b/user/user.pkl
@@ -1,5 +1,7 @@
+@go.Package { name = "github.com/declix/pkl-declix/user" }
 abstract module declix.user
 
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
 import "../declix.pkl"
 
 typealias Missing = declix.Missing

--- a/user/user.pkl
+++ b/user/user.pkl
@@ -1,7 +1,7 @@
 @go.Package { name = "github.com/declix/pkl-declix/user" }
 abstract module declix.user
 
-import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.11.0#/go.pkl"
+import "@go/go.pkl"
 import "../declix.pkl"
 
 typealias Missing = declix.Missing


### PR DESCRIPTION
## Summary
- Added @go.Package annotations to all main Pkl modules to enable Go code generation
- Each module now has a corresponding Go package path under `github.com/declix/pkl-declix/*`
- Added pkl-go dependency imports to support the @go.Package annotation functionality

## Changes
- **declix.pkl**: `github.com/declix/pkl-declix`
- **systemd/systemd.pkl**: `github.com/declix/pkl-declix/systemd`  
- **user/user.pkl**: `github.com/declix/pkl-declix/user`
- **fs/fs.pkl**: `github.com/declix/pkl-declix/fs`
- **apt/apt.pkl**: `github.com/declix/pkl-declix/apt`
- **dpkg/dpkg.pkl**: `github.com/declix/pkl-declix/dpkg`
- **resources.pkl**: `github.com/declix/pkl-declix/resources`

## Benefits
- Enables developers to generate type-safe Go code from Pkl configuration schemas using `pkl-gen-go`
- Provides proper Go package mapping for all modules
- Maintains backward compatibility with existing Pkl functionality

## Test plan
- [x] All existing tests pass
- [x] Pkl modules can be evaluated without errors  
- [x] Package annotations are properly formatted and accessible

🤖 Generated with [Claude Code](https://claude.ai/code)