### PR TITLE
fix: exclude node_modules from release archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .jj/
 .pkl-lsp/
 *.pkl-actual.pcf
+node_modules/


### PR DESCRIPTION
## Summary
- Add `node_modules/` to `.gitignore` to prevent inclusion in pkl project packages
- Fixes issue where release archives were 12MB+ due to including entire node_modules directory
- Release archives will now be just a few KB containing only the actual Pkl source files

## Test plan
- [x] Verify node_modules is excluded from git tracking
- [ ] Test release process generates smaller archives (can be verified in next release)

🤖 Generated with [Claude Code](https://claude.ai/code)