### PR TITLE
fix: add exclude property to PklProject to properly exclude node_modules

### DIFF
--- a/PklProject
+++ b/PklProject
@@ -9,6 +9,10 @@ package {
         "Mike Aizatsky <mike.aizatsky@gmail.com>"
     }
     packageZipUrl = "https://github.com/declix/\(name)/releases/download/\(version)/\(name)@\(version).zip"
+    exclude {
+        "node_modules"
+        "node_modules/**"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- Add `exclude` block to package configuration in PklProject
- Exclude `"node_modules"` and `"node_modules/**"` from package archives
- Fixes the root cause of 12MB release archives by using Pkl's native exclude functionality

## Test plan
- [x] Run `just test` - all tests pass
- [x] Test packaging with `just release 0.8.2` - package size reduced from 12MB to 13KB
- [x] Verify exclude property syntax matches Pkl documentation examples

## Technical Details
The previous attempt using `.gitignore` didn't work because `pkl project package` doesn't respect git ignore patterns. The `exclude` property in the PklProject package configuration is the proper Pkl-specific way to exclude files from packages.

🤖 Generated with [Claude Code](https://claude.ai/code)